### PR TITLE
add initial schemas for Telco Guide 1.0

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,98 @@
+# Schemas of OpenChain Telco Guide
+This directory is an implementation of json schemas of Telco Guide. The file [openchain-telco-guide-v1.0-schema.json](openchain-telco-guide-v1.0-schema.json) is just the json schema file you can take to your project. 
+
+As further described below, a technology viewpoint is shown below how to generate json schema file from scratch if you wanna a clear comprehension of underlying logic.
+
+## SPDX 2.2 and SPDX 2.3
+In the specification of OpenChain Telco Guide, we say 'An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3 of the standard'. By 05/08/2024, v2.2, v2.2.1, v2.2.2 and v2.3 have been released in github website. We choose v2.2.2 and v2.3 as origin json schema implementation.
+
+The difference between spdx 2.2 and spdx 2.3 is that spdx 2.3 require less license info. For example, you can see concluded license field in spdx 2.2 [link](https://spdx.github.io/spdx-spec/v2.2.2/package-information/#713-concluded-license-field) and in spdx 2.3 [link](https://spdx.github.io/spdx-spec/v2.3/package-information/#713-concluded-license-field).
+
+In the directory `internal`, you can see four files about spdx json schema. 
+- [spdx-v2.2.2-origin-schema.json](internal/spdx-v2.2.2-origin-schema.json)
+- [spdx-v2.2.2-fix-schema.json](internal/spdx-v2.2.2-fix-schema.json)
+- [spdx-v2.3-origin-schema.json](internal/spdx-v2.3-origin-schema.json)
+- [spdx-v2.3-fix-schema.json](internal/spdx-v2.3-fix-schema.json)
+
+The term 'origin' means that the file is copied from official github website. The file [spdx-v2.2.2-origin-schema.json](internal/spdx-v2.2.2-origin-schema.json) comes from [link](https://github.com/spdx/spdx-spec/blob/v2.2.2/schemas/spdx-schema.json). And the file [spdx-v2.3-origin-schema.json](internal/spdx-v2.3-origin-schema.json) comes from [link](https://github.com/spdx/spdx-spec/blob/v2.3/schemas/spdx-schema.json).Also, the v2.2.2 specification can be found in [link](https://spdx.github.io/spdx-spec/v2.2.2/) and the v2.3 specification can be found in [link](https://spdx.github.io/spdx-spec/v2.3/).
+
+The term 'fix' means something has been fixed from the origin files. Why should we do it? There are three main reasons. 
+
+Firstly, do bugfix works. Spdx github project [link](https://github.com/spdx/spdx-spec/) is rapidly developed. Unfortunately, official json schema implementations in SPDX github are not consistent with official SPDX specifications. To confirm this, a [json_schema_compare.py](internal/json_schema_compare.py) script is developed. The comparison between SPDX v2.2.2 origin and fix one can be shown below.
+
+```
+internal $ python3 json_schema_compare.py -f spdx-v2.2.2-origin-schema.json spdx-v2.2.2-fix-schema.json 
+{
+    "field_mandatory_comparison": {
+        "more_fields": [
+            "doc(object)->snippets(array)->snippets_item(object)->name"
+        ],
+        "less_fields": [
+            "doc(object)->documentNamespace",
+            "doc(object)->creationInfo(object)->creators",
+            "doc(object)->files(array)->files_item(object)->checksums",
+            "doc(object)->files(array)->files_item(object)->licenseInfoInFiles",
+            "doc(object)->snippets(array)->snippets_item(object)->ranges"
+        ]
+    },
+    "field_existence_comparison": {}
+}
+```
+In SPDX 2.2.2 specifications, `name` field in `snippets` in not mandatory, while in SPDX 2.2.2 json schema implementation is mandatory. And field `documentNamespace`, field `checksums` in `files`, field `licenseInfoInFiles` in `files` and field `ranges` in `snippets` is mandatory in SPDX 2.2.2 specifications, while not mandatory in json schema implementation. It is the same to SPDX 2.3 version. The bugfixes for spdx have been pulled request to official github project.
+
+Secondly, it is impossible to reuse SPDX 2.2.2/2.3 json schema implementation in Telco Guide because declarations of `"additionalProperties": false` exist in it, which means you cannot extend any other field. So the fix one will omit this declaration to extend more fields.
+
+Thirdly, arrange order of fields in implementation according to order of fields in official specifications to make implementation more human-readable. In origin json schema implementation of SPDX, orders of fields are in a messy.
+
+## Openchain Telco Guide JSON Schema
+ASPDX 2.2 and SPDX 2.3 are not compatible
+```
+internal $ python3 json_schema_compare.py -f spdx-v2.3-fix-schema.json spdx-v2.2.2-fix-schema.json 
+{
+    "field_mandatory_comparison": {
+        "less_fields": [
+            "doc(object)->files(array)->files_item(object)->copyrightText",
+            "doc(object)->files(array)->files_item(object)->licenseConcluded",
+            "doc(object)->files(array)->files_item(object)->licenseInfoInFiles",
+            "doc(object)->packages(array)->packages_item(object)->copyrightText",
+            "doc(object)->packages(array)->packages_item(object)->licenseConcluded",
+            "doc(object)->packages(array)->packages_item(object)->licenseDeclared",
+            "doc(object)->snippets(array)->snippets_item(object)->copyrightText",
+            "doc(object)->snippets(array)->snippets_item(object)->licenseConcluded"
+        ]
+    },
+    "field_existence_comparison": {
+        "more_fields": [
+            "doc(object)->packages(array)->packages_item(object)->builtDate(string)",
+            "doc(object)->packages(array)->packages_item(object)->primaryPackagePurpose(string)",
+            "doc(object)->packages(array)->packages_item(object)->releaseDate(string)",
+            "doc(object)->packages(array)->packages_item(object)->validUntilDate(string)"
+        ]
+    }
+}
+```
+SPDX 2.3 add four fields that are all not mandatory in comparison with SPDX 2.2 and require less license info mandatory fields. This means if it meets SPDX 2.3, it will meet SPDX 2.2. So we choose SPDX 2.3 as a base implementation of Telco Guide. Then we add `MUST` feild in Telco Guide which can be shown below.
+```
+internal $ python3 json_schema_compare.py -f ../openchain-telco-guide-v1.0-schema.json spdx-v2.3-fix-schema.json 
+{
+    "field_mandatory_comparison": {
+        "more_fields": [
+            "doc(object)->packages(array)->packages_item(object)->copyrightText",
+            "doc(object)->packages(array)->packages_item(object)->licenseConcluded",
+            "doc(object)->packages(array)->packages_item(object)->licenseDeclared",
+            "doc(object)->packages(array)->packages_item(object)->supplier",
+            "doc(object)->packages(array)->packages_item(object)->version"
+        ]
+    },
+    "field_existence_comparison": {
+        "more_fields": [
+            "doc(object)->packages(array)->packages_item(object)->version(string)"
+        ]
+    }
+}
+```
+The difference between Telco Guide and SPDX 2.3 can be shown below.
+- The field `version` in field `packages` is added into Telco Guide and declared as mandatory. 
+- The field `copyrightText`, `licenseConcluded`, `licenseDeclared`, `supplier`, `version` in field `packages` is declared as mandatory. 
+- add descriptions into some fields json schema.
+- Revise `$id` and `title`.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -45,7 +45,7 @@ Secondly, it is impossible to reuse SPDX 2.2.2/2.3 json schema implementation in
 Thirdly, arrange order of fields in implementation according to order of fields in official specifications to make implementation more human-readable. In origin json schema implementation of SPDX, orders of fields are in a messy.
 
 ## Openchain Telco Guide JSON Schema
-ASPDX 2.2 and SPDX 2.3 are not compatible
+SPDX 2.2 and SPDX 2.3 are not compatible!
 ```
 internal $ python3 json_schema_compare.py -f spdx-v2.3-fix-schema.json spdx-v2.2.2-fix-schema.json 
 {

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,7 +4,7 @@ This directory is an implementation of json schemas of Telco Guide. The file [op
 As further described below, a technology viewpoint is shown below how to generate json schema file from scratch if you wanna a clear comprehension of underlying logic.
 
 ## SPDX 2.2 and SPDX 2.3
-In the specification of OpenChain Telco Guide, we say 'An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3 of the standard'. By 05/08/2024, v2.2, v2.2.1, v2.2.2 and v2.3 have been released in github website. We choose v2.2.2 and v2.3 as origin json schema implementation.
+In the specification of OpenChain Telco Guide, we say 'An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3 of the standard'. By 2024-08-05, v2.2, v2.2.1, v2.2.2 and v2.3 have been released in github website. We choose v2.2.2 and v2.3 as origin json schema implementation.
 
 The difference between spdx 2.2 and spdx 2.3 is that spdx 2.3 require less license info. For example, you can see concluded license field in spdx 2.2 [link](https://spdx.github.io/spdx-spec/v2.2.2/package-information/#713-concluded-license-field) and in spdx 2.3 [link](https://spdx.github.io/spdx-spec/v2.3/package-information/#713-concluded-license-field).
 
@@ -92,7 +92,7 @@ internal $ python3 json_schema_compare.py -f ../openchain-telco-guide-v1.0-schem
 }
 ```
 The difference between Telco Guide and SPDX 2.3 can be shown below.
-- The field `version` in field `packages` is added into Telco Guide and declared as mandatory. 
+- The field `version` in field `packages` is added into Telco Guide. 
 - The field `copyrightText`, `licenseConcluded`, `licenseDeclared`, `supplier`, `version` in field `packages` is declared as mandatory. 
 - add descriptions into some fields json schema.
 - Revise `$id` and `title`.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,10 +1,10 @@
-# Schemas of OpenChain Telco Guide
-This directory is an implementation of json schemas of Telco Guide. The file [openchain-telco-guide-v1.0-schema.json](openchain-telco-guide-v1.0-schema.json) is just the json schema file you can take to your project. 
+# Schemas of OpenChain Telco SBOM Guide
+This directory is an implementation of json schemas of OpenChain Telco SBOM Guide. The file [openchain-telco-sbom-guide-1.0-schema.json](openchain-telco-sbom-guide-1.0-schema.json) is just the json schema file you can take to your project. 
 
 As further described below, a technology viewpoint is shown below how to generate json schema file from scratch if you wanna a clear comprehension of underlying logic.
 
 ## SPDX 2.2 and SPDX 2.3
-In the specification of OpenChain Telco Guide, we say 'An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3 of the standard'. By 2024-08-05, v2.2, v2.2.1, v2.2.2 and v2.3 have been released in github website. We choose v2.2.2 and v2.3 as origin json schema implementation.
+In the specification of OpenChain Telco SBOM Guide, we say 'An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3 of the standard'. By 2024-08-05, v2.2, v2.2.1, v2.2.2 and v2.3 have been released in github website. We choose v2.2.2 and v2.3 as origin json schema implementation.
 
 The difference between spdx 2.2 and spdx 2.3 is that spdx 2.3 require less license info. For example, you can see concluded license field in spdx 2.2 [link](https://spdx.github.io/spdx-spec/v2.2.2/package-information/#713-concluded-license-field) and in spdx 2.3 [link](https://spdx.github.io/spdx-spec/v2.3/package-information/#713-concluded-license-field).
 
@@ -40,11 +40,11 @@ internal $ python3 json_schema_compare.py -f spdx-v2.2.2-origin-schema.json spdx
 ```
 In SPDX 2.2.2 specifications, `name` field in `snippets` in not mandatory, while in SPDX 2.2.2 json schema implementation is mandatory. And field `documentNamespace`, field `checksums` in `files`, field `licenseInfoInFiles` in `files` and field `ranges` in `snippets` is mandatory in SPDX 2.2.2 specifications, while not mandatory in json schema implementation. It is the same to SPDX 2.3 version. The bugfixes for spdx have been pulled request to official github project.
 
-Secondly, it is impossible to reuse SPDX 2.2.2/2.3 json schema implementation in Telco Guide because declarations of `"additionalProperties": false` exist in it, which means you cannot extend any other field. So the fix one will omit this declaration to extend more fields.
+Secondly, it is impossible to reuse SPDX 2.2.2/2.3 json schema implementation in Open Chain Telco SBOM Guide because declarations of `"additionalProperties": false` exist in it, which means you cannot extend any other field. So the fix one will omit this declaration to extend more fields.
 
 Thirdly, arrange order of fields in implementation according to order of fields in official specifications to make implementation more human-readable. In origin json schema implementation of SPDX, orders of fields are in a messy.
 
-## Openchain Telco Guide JSON Schema
+## Openchain Telco SBOM Guide JSON Schema
 SPDX 2.2 and SPDX 2.3 are not compatible!
 ```
 internal $ python3 json_schema_compare.py -f spdx-v2.3-fix-schema.json spdx-v2.2.2-fix-schema.json 
@@ -71,28 +71,26 @@ internal $ python3 json_schema_compare.py -f spdx-v2.3-fix-schema.json spdx-v2.2
     }
 }
 ```
-SPDX 2.3 add four fields that are all not mandatory in comparison with SPDX 2.2 and require less license info mandatory fields. This means if it meets SPDX 2.3, it will meet SPDX 2.2. So we choose SPDX 2.3 as a base implementation of Telco Guide. Then we add `MUST` feild in Telco Guide which can be shown below.
+SPDX 2.3 add four fields that are all not mandatory in comparison with SPDX 2.2 and require less license info mandatory fields. This means if it meets SPDX 2.2, it will meet SPDX 2.3. So we choose SPDX 2.3 as a base implementation of Open Chain Telco SBOM Guide. Then we add `MUST` feild in Open Chain Telco SBOM Guide which can be shown below.
 ```
-internal $ python3 json_schema_compare.py -f ../openchain-telco-guide-v1.0-schema.json spdx-v2.3-fix-schema.json 
+internal $ python3 json_schema_compare.py -f ../openchain-telco-sbom-guide-1.0-schema.json spdx-v2.3-fix-schema.jso
+n
 {
     "field_mandatory_comparison": {
         "more_fields": [
+            "doc(object)->creationInfo(object)->comment",
             "doc(object)->packages(array)->packages_item(object)->copyrightText",
             "doc(object)->packages(array)->packages_item(object)->licenseConcluded",
             "doc(object)->packages(array)->packages_item(object)->licenseDeclared",
             "doc(object)->packages(array)->packages_item(object)->supplier",
-            "doc(object)->packages(array)->packages_item(object)->version"
+            "doc(object)->packages(array)->packages_item(object)->versionInfo"
         ]
     },
-    "field_existence_comparison": {
-        "more_fields": [
-            "doc(object)->packages(array)->packages_item(object)->version(string)"
-        ]
-    }
+    "field_existence_comparison": {}
 }
 ```
-The difference between Telco Guide and SPDX 2.3 can be shown below.
-- The field `version` in field `packages` is added into Telco Guide. 
-- The field `copyrightText`, `licenseConcluded`, `licenseDeclared`, `supplier`, `version` in field `packages` is declared as mandatory. 
+The difference between Open Chain Telco SBOM Guide and SPDX 2.3 can be shown below.
+- The field `comment` in field `createInfo` in declared as mandatory.
+- The field `copyrightText`, `licenseConcluded`, `licenseDeclared`, `supplier`, `versionInfo` in field `packages` is declared as mandatory. 
 - add descriptions into some fields json schema.
 - Revise `$id` and `title`.

--- a/schemas/internal/json_schema_compare.py
+++ b/schemas/internal/json_schema_compare.py
@@ -1,0 +1,129 @@
+import json
+import argparse
+
+class SchemaPath(object):
+    def __init__(self, name, schema, parent=None) -> None:
+        self.name = name
+        self.type = schema["type"]
+        self.parent = parent
+        self.schema = schema
+    
+    def __str__(self) -> str:
+        result = ""
+        if self.parent is not None:
+            result += str(self.parent)
+            pass
+        if result == "":
+            result = self._get_current_str()
+        else:
+            result += "->" + self._get_current_str()
+        return result
+    
+    def _get_current_str(self) -> str:
+        return "{}({})".format(self.name, self.type)
+
+    def __lt__(self, other):
+        return str(self) < str(other)
+
+def readJson(f_name):
+    with open(f_name, "r") as f:
+        try:
+            result = json.load(f)
+        except Exception as e:
+            return None
+        return result
+
+def compare(lefts, rights):
+    # double pos
+    left_pos = right_pos = 0
+    left_length = len(lefts)
+    right_length = len(rights)
+    commons = []
+    left_right_differences = []
+    right_left_differences = []
+    while left_pos < left_length and right_pos < right_length:
+        left = lefts[left_pos]
+        right = rights[right_pos]
+        if str(left) == str(right):
+            commons.append([left, right])
+            left_pos += 1
+            right_pos += 1
+        elif str(lefts[left_pos]) < str(rights[right_pos]):
+            left_right_differences.append(left)
+            left_pos += 1
+        else:
+            right_left_differences.append(right)
+            right_pos += 1
+    while left_pos < left_length:
+        left_right_differences.append(lefts[left_pos])
+        left_pos += 1
+    while right_pos < right_length:
+        right_left_differences.append(rights[right_pos])
+        right_pos += 1
+    return commons, left_right_differences, right_left_differences
+
+def retrive_root_schema(schema):
+    results = []
+    def retrive(name, schema, parent=None):
+        d = SchemaPath(name, schema, parent=parent)
+        if d.type == "object":
+            results.append(d)
+            for key in schema.get("properties", {}):
+                retrive(key, schema["properties"][key], d)
+        elif d.type == "array":
+            retrive(name+"_item", schema["items"], d)
+        else:
+            results.append(d)
+
+    retrive("doc", schema)
+    return sorted(results)
+
+def compare_file(fname_1, fname_2):
+    left_json_schema_paths = retrive_root_schema(readJson(f_name=fname_1))
+    right_json_schema_paths = retrive_root_schema(readJson(f_name=fname_2))
+    commons, left_right_differences, right_left_differences = compare(left_json_schema_paths, right_json_schema_paths)
+    comparison_result = {
+        "field_mandatory_comparison": {},
+        "field_existence_comparison": {}
+    }
+    if len(left_right_differences) > 0:
+        more_fields = []
+        for key in left_right_differences:
+            more_fields.append(str(key))
+        if len(more_fields) > 0:
+            comparison_result["field_existence_comparison"]["more_fields"] = more_fields
+    if len(right_left_differences) > 0:
+        less_fields = []
+        for key in right_left_differences:
+            less_fields.append(str(key))
+        if len(less_fields) > 0:
+            comparison_result["field_existence_comparison"]["less_fields"] = less_fields
+    more_fields = []
+    less_fields = []
+    for key in commons:
+        _, _left_right_differences, _right_left_differences = compare(sorted(key[0].schema.get("required",[])), sorted(key[1].schema.get("required",[])))
+        if len(_left_right_differences) > 0:
+            for _key in _left_right_differences:
+                more_fields.append("{}->{}".format(str(key[0]), _key))
+        if len(_right_left_differences) > 0:
+            for _key in _right_left_differences:
+                less_fields.append("{}->{}".format(str(key[0]), _key))
+    if len(more_fields) > 0:
+        comparison_result["field_mandatory_comparison"]["more_fields"] = more_fields
+    if len(less_fields) > 0:
+        comparison_result["field_mandatory_comparison"]["less_fields"] = less_fields
+    return comparison_result
+
+def print_result(comparison_result):
+    json_str = json.dumps(comparison_result, indent=4)
+    print(json_str)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="compare two json schema, such as fields and required info")
+    parser.add_argument("-f", "--file", dest="file", nargs="+", help="file")
+    args = parser.parse_args()
+    if len(args.file) != 2:
+        print("need 2 params, filenames of json schema")
+        exit(-1)
+    result = compare_file(args.file[0], args.file[1])
+    print_result(result)

--- a/schemas/internal/spdx-v2.2.2-fix-schema.json
+++ b/schemas/internal/spdx-v2.2.2-fix-schema.json
@@ -1,0 +1,893 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://spdx.org/rdf/terms",
+    "title": "SPDX 2.2",
+    "type": "object",
+    "required": [
+        "spdxVersion",
+        "dataLicense",
+        "SPDXID",
+        "name",
+        "documentNamespace",
+        "creationInfo"
+    ],
+    "properties": {
+        "spdxVersion": {
+            "description": "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+            "type": "string"
+        },
+        "dataLicense": {
+            "description": "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+            "type": "string"
+        },
+        "SPDXID": {
+            "type": "string",
+            "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+        },
+        "name": {
+            "description": "Identify name of this SpdxElement.",
+            "type": "string"
+        },
+        "documentNamespace": {
+            "type": "string",
+            "description": "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+        },
+        "documentDescribes": {
+            "description": "Packages, files and/or Snippets described by this SPDX document",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "externalDocumentRefs": {
+            "description": "Identify any external SPDX documents referenced within this SPDX document.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "externalDocumentId",
+                    "checksum",
+                    "spdxDocument"
+                ],
+                "properties": {
+                    "externalDocumentId": {
+                        "description": "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                        "type": "string"
+                    },
+                    "checksum": {
+                        "type": "object",
+                        "required": [
+                            "algorithm",
+                            "checksumValue"
+                        ],
+                        "properties": {
+                            "algorithm": {
+                                "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                "type": "string",
+                                "enum": [
+                                    "SHA256",
+                                    "SHA1",
+                                    "SHA384",
+                                    "MD2",
+                                    "MD4",
+                                    "SHA512",
+                                    "MD6",
+                                    "MD5",
+                                    "SHA224"
+                                ]
+                            },
+                            "checksumValue": {
+                                "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                "type": "string"
+                            }
+                        },
+                        "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                    },
+                    "spdxDocument": {
+                        "description": "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+                        "type": "string"
+                    }
+                },
+                "description": "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+            }
+        },
+        "creationInfo": {
+            "type": "object",
+            "required": [
+                "creators",
+                "created"
+            ],
+            "properties": {
+                "licenseListVersion": {
+                    "description": "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+                    "type": "string"
+                },
+                "creators": {
+                    "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                    "type": "array",
+                    "items": {
+                        "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "created": {
+                    "description": "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string",
+                    "description": "an optional field for creator of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields."
+                }
+            },
+            "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "comment": {
+            "type": "string",
+            "description": "an optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document."
+        },
+        "packages": {
+            "description": "Packages referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "SPDXID",
+                    "downloadLocation",
+                    "licenseConcluded",
+                    "licenseDeclared",
+                    "copyrightText"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "versionInfo": {
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "type": "string"
+                    },
+                    "packageFileName": {
+                        "description": "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                        "type": "string"
+                    },
+                    "supplier": {
+                        "description": "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "originator": {
+                        "description": "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "downloadLocation": {
+                        "description": "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                        "type": "string"
+                    },
+                    "filesAnalyzed": {
+                        "description": "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                        "type": "boolean"
+                    },
+                    "packageVerificationCode": {
+                        "type": "object",
+                        "required": [
+                            "packageVerificationCodeValue"
+                        ],
+                        "properties": {
+                            "packageVerificationCodeValue": {
+                                "description": "The actual package verification code as a hex encoded value. Use sha1 algorithm",
+                                "type": "string"
+                            },
+                            "packageVerificationCodeExcludedFiles": {
+                                "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "homepage": {
+                        "type": "string"
+                    },
+                    "sourceInfo": {
+                        "description": "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoFromFiles": {
+                        "description": "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseDeclared": {
+                        "description": "License expression for licenseDeclared. See SPDX Annex D for the license expression syntax.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+                        "type": "string"
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "Provides a short description of the package.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Provides a detailed description of the package.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "externalRefs": {
+                        "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "referenceCategory",
+                                "referenceType",
+                                "referenceLocator"
+                            ],
+                            "properties": {
+                                "referenceCategory": {
+                                    "description": "Category for the external reference",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "SECURITY",
+                                        "PACKAGE_MANAGER"
+                                    ]
+                                },
+                                "referenceType": {
+                                    "description": "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                                    "type": "string"
+                                },
+                                "referenceLocator": {
+                                    "description": "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "hasFiles": {
+                        "description": "Indicates that a particular file belongs to a package.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "files": {
+            "description": "Files referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "fileName",
+                    "SPDXID",
+                    "checksums",
+                    "licenseConcluded",
+                    "licenseInfoInFiles",
+                    "copyrightText"
+                ],
+                "properties": {
+                    "fileName": {
+                        "description": "The name of the file relative to the root of the package.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "fileTypes": {
+                        "description": "The type of the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "The type of the file.",
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "DOCUMENTATION",
+                                "IMAGE",
+                                "VIDEO",
+                                "ARCHIVE",
+                                "SPDX",
+                                "APPLICATION",
+                                "SOURCE",
+                                "BINARY",
+                                "TEXT",
+                                "AUDIO"
+                            ]
+                        }
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        },
+                        "minItems": 1
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInFiles": {
+                        "description": "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                            "type": "string"
+                        },
+                        "minItems": 1
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "artifactOfs": {
+                        "description": "Deprecated. Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    },
+                    "comment": {
+                        "description": "This field provides a place for the SPDX file creator to record any general comments about the file.",
+                        "type": "string"
+                    },
+                    "noticeText": {
+                        "description": "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                        "type": "string"
+                    },
+                    "fileContributors": {
+                        "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                            "type": "string"
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "fileDependencies": {
+                        "description": "Deprecated. The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "snippets": {
+            "description": "Snippets referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "SPDXID",
+                    "snippetFromFile",
+                    "ranges",
+                    "licenseConcluded",
+                    "copyrightText"
+                ],
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "snippetFromFile": {
+                        "description": "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                        "type": "string"
+                    },
+                    "ranges": {
+                        "description": "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "endPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                },
+                                "startPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "endPointer",
+                                "startPointer"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInSnippets": {
+                        "description": "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "hasExtractedLicensingInfos": {
+            "description": "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "licenseId",
+                    "extractedText"
+                ],
+                "properties": {
+                    "licenseId": {
+                        "description": "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+                        "type": "string"
+                    },
+                    "extractedText": {
+                        "description": "Verbatim license or licensing notice text that was discovered.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "seeAlsos": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "crossRefs": {
+                        "description": "Cross Reference Detail for a license SeeAlso URL",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "url"
+                            ],
+                            "properties": {
+                                "isWayBackLink": {
+                                    "description": "True if the License SeeAlso URL points to a Wayback archive",
+                                    "type": "boolean"
+                                },
+                                "match": {
+                                    "description": "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                                    "type": "string"
+                                },
+                                "timestamp": {
+                                    "description": "Timestamp",
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "description": "The ordinal order of this element within a list",
+                                    "type": "integer"
+                                },
+                                "url": {
+                                    "description": "URL Reference",
+                                    "type": "string"
+                                },
+                                "isLive": {
+                                    "description": "Indicate a URL is still a live accessible location on the public internet",
+                                    "type": "boolean"
+                                },
+                                "isValid": {
+                                    "description": "True if the URL is a valid well formed URL",
+                                    "type": "boolean"
+                                }
+                            },
+                            "description": "Cross reference details for the a URL reference"
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                },
+                "description": "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+            }
+        },
+        "relationships": {
+            "description": "Relationships referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "spdxElementId",
+                    "relatedSpdxElement",
+                    "relationshipType"
+                ],
+                "properties": {
+                    "spdxElementId": {
+                        "type": "string",
+                        "description": "Id to which the SPDX element is related"
+                    },
+                    "relationshipType": {
+                        "description": "Describes the type of relationship between two SPDX elements.",
+                        "type": "string",
+                        "enum": [
+                            "VARIANT_OF",
+                            "COPY_OF",
+                            "PATCH_FOR",
+                            "TEST_DEPENDENCY_OF",
+                            "CONTAINED_BY",
+                            "DATA_FILE_OF",
+                            "OPTIONAL_COMPONENT_OF",
+                            "ANCESTOR_OF",
+                            "GENERATES",
+                            "CONTAINS",
+                            "OPTIONAL_DEPENDENCY_OF",
+                            "FILE_ADDED",
+                            "DEV_DEPENDENCY_OF",
+                            "DEPENDENCY_OF",
+                            "BUILD_DEPENDENCY_OF",
+                            "DESCRIBES",
+                            "PREREQUISITE_FOR",
+                            "HAS_PREREQUISITE",
+                            "PROVIDED_DEPENDENCY_OF",
+                            "DYNAMIC_LINK",
+                            "DESCRIBED_BY",
+                            "METAFILE_OF",
+                            "DEPENDENCY_MANIFEST_OF",
+                            "PATCH_APPLIED",
+                            "RUNTIME_DEPENDENCY_OF",
+                            "TEST_OF",
+                            "TEST_TOOL_OF",
+                            "DEPENDS_ON",
+                            "FILE_MODIFIED",
+                            "DISTRIBUTION_ARTIFACT",
+                            "DOCUMENTATION_OF",
+                            "GENERATED_FROM",
+                            "STATIC_LINK",
+                            "OTHER",
+                            "BUILD_TOOL_OF",
+                            "TEST_CASE_OF",
+                            "PACKAGE_OF",
+                            "DESCENDANT_OF",
+                            "FILE_DELETED",
+                            "EXPANDED_FROM_ARCHIVE",
+                            "DEV_TOOL_OF",
+                            "EXAMPLE_OF"
+                        ]
+                    },
+                    "relatedSpdxElement": {
+                        "description": "SPDX ID for SpdxElement.  A related SpdxElement.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "annotations": {
+            "description": "Provide additional information about an SpdxElement.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "annotationDate",
+                    "comment",
+                    "annotator",
+                    "annotationType"
+                ],
+                "properties": {
+                    "annotator": {
+                        "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                        "type": "string"
+                    },
+                    "annotationDate": {
+                        "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "annotationType": {
+                        "description": "Type of the annotation.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "REVIEW"
+                        ]
+                    }
+                },
+                "description": "An Annotation is a comment on an SpdxItem by an agent."
+            }
+        },
+        "revieweds": {
+            "description": "Deprecated. Reviewed",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "reviewDate"
+                ],
+                "properties": {
+                    "reviewer": {
+                        "description": "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "reviewDate": {
+                        "description": "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/internal/spdx-v2.2.2-origin-schema.json
+++ b/schemas/internal/spdx-v2.2.2-origin-schema.json
@@ -1,0 +1,905 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://spdx.org/rdf/terms",
+    "title": "SPDX 2.2",
+    "type": "object",
+    "properties": {
+        "SPDXID": {
+            "type": "string",
+            "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+        },
+        "revieweds": {
+            "description": "Reviewed",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "reviewer": {
+                        "description": "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "reviewDate": {
+                        "description": "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "reviewDate"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "hasExtractedLicensingInfos": {
+            "description": "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "seeAlsos": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "crossRefs": {
+                        "description": "Cross Reference Detail for a license SeeAlso URL",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "isWayBackLink": {
+                                    "description": "True if the License SeeAlso URL points to a Wayback archive",
+                                    "type": "boolean"
+                                },
+                                "match": {
+                                    "description": "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                                    "type": "string"
+                                },
+                                "timestamp": {
+                                    "description": "Timestamp",
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "description": "The ordinal order of this element within a list",
+                                    "type": "integer"
+                                },
+                                "url": {
+                                    "description": "URL Reference",
+                                    "type": "string"
+                                },
+                                "isLive": {
+                                    "description": "Indicate a URL is still a live accessible location on the public internet",
+                                    "type": "boolean"
+                                },
+                                "isValid": {
+                                    "description": "True if the URL is a valid well formed URL",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "url"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Cross reference details for the a URL reference"
+                        }
+                    },
+                    "licenseId": {
+                        "description": "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+                        "type": "string"
+                    },
+                    "extractedText": {
+                        "description": "Verbatim license or licensing notice text that was discovered.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "licenseId",
+                    "extractedText"
+                ],
+                "additionalProperties": false,
+                "description": "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+            }
+        },
+        "name": {
+            "description": "Identify name of this SpdxElement.",
+            "type": "string"
+        },
+        "comment": {
+            "type": "string"
+        },
+        "spdxVersion": {
+            "description": "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+            "type": "string"
+        },
+        "annotations": {
+            "description": "Provide additional information about an SpdxElement.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "annotationDate": {
+                        "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "annotator": {
+                        "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                        "type": "string"
+                    },
+                    "annotationType": {
+                        "description": "Type of the annotation.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "REVIEW"
+                        ]
+                    }
+                },
+                "required": [
+                    "annotationDate",
+                    "comment",
+                    "annotator",
+                    "annotationType"
+                ],
+                "additionalProperties": false,
+                "description": "An Annotation is a comment on an SpdxItem by an agent."
+            }
+        },
+        "dataLicense": {
+            "description": "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+            "type": "string"
+        },
+        "externalDocumentRefs": {
+            "description": "Identify any external SPDX documents referenced within this SPDX document.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "externalDocumentId": {
+                        "description": "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                        "type": "string"
+                    },
+                    "checksum": {
+                        "type": "object",
+                        "properties": {
+                            "algorithm": {
+                                "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                "type": "string",
+                                "enum": [
+                                    "SHA256",
+                                    "SHA1",
+                                    "SHA384",
+                                    "MD2",
+                                    "MD4",
+                                    "SHA512",
+                                    "MD6",
+                                    "MD5",
+                                    "SHA224"
+                                ]
+                            },
+                            "checksumValue": {
+                                "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "algorithm",
+                            "checksumValue"
+                        ],
+                        "additionalProperties": false,
+                        "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                    },
+                    "spdxDocument": {
+                        "description": "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "externalDocumentId",
+                    "checksum",
+                    "spdxDocument"
+                ],
+                "additionalProperties": false,
+                "description": "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+            }
+        },
+        "creationInfo": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+                    "type": "string"
+                },
+                "creators": {
+                    "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                        "type": "string"
+                    }
+                },
+                "licenseListVersion": {
+                    "description": "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "created"
+            ],
+            "additionalProperties": false,
+            "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "documentNamespace": {
+            "type": "string",
+            "description": "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+        },
+        "documentDescribes": {
+            "description": "Packages, files and/or Snippets described by this SPDX document",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "packages": {
+            "description": "Packages referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "supplier": {
+                        "description": "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "homepage": {
+                        "type": "string"
+                    },
+                    "licenseDeclared": {
+                        "description": "License expression for licenseDeclared.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+                        "type": "string"
+                    },
+                    "packageVerificationCode": {
+                        "type": "object",
+                        "properties": {
+                            "packageVerificationCodeValue": {
+                                "description": "The actual package verification code as a hex encoded value.",
+                                "type": "string"
+                            },
+                            "packageVerificationCodeExcludedFiles": {
+                                "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "packageVerificationCodeValue"
+                        ],
+                        "additionalProperties": false,
+                        "description": "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "additionalProperties": false,
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "downloadLocation": {
+                        "description": "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                        "type": "string"
+                    },
+                    "filesAnalyzed": {
+                        "description": "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                        "type": "boolean"
+                    },
+                    "externalRefs": {
+                        "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "referenceCategory": {
+                                    "description": "Category for the external reference",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "SECURITY",
+                                        "PACKAGE_MANAGER"
+                                    ]
+                                },
+                                "referenceLocator": {
+                                    "description": "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                                    "type": "string"
+                                },
+                                "referenceType": {
+                                    "description": "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "referenceCategory",
+                                "referenceLocator",
+                                "referenceType"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "hasFiles": {
+                        "description": "Indicates that a particular file belongs to a package.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                            "type": "string"
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "Provides a short description of the package.",
+                        "type": "string"
+                    },
+                    "originator": {
+                        "description": "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "packageFileName": {
+                        "description": "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                        "type": "string"
+                    },
+                    "licenseInfoFromFiles": {
+                        "description": "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+                        "type": "string"
+                    },
+                    "versionInfo": {
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "type": "string"
+                    },
+                    "sourceInfo": {
+                        "description": "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Provides a detailed description of the package.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "licenseDeclared",
+                    "downloadLocation",
+                    "name",
+                    "copyrightText",
+                    "licenseConcluded"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "files": {
+            "description": "Files referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "fileTypes": {
+                        "description": "The type of the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "The type of the file.",
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "DOCUMENTATION",
+                                "IMAGE",
+                                "VIDEO",
+                                "ARCHIVE",
+                                "SPDX",
+                                "APPLICATION",
+                                "SOURCE",
+                                "BINARY",
+                                "TEXT",
+                                "AUDIO"
+                            ]
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "additionalProperties": false,
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "noticeText": {
+                        "description": "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                        "type": "string"
+                    },
+                    "artifactOfs": {
+                        "description": "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "fileName": {
+                        "description": "The name of the file relative to the root of the package.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "fileContributors": {
+                        "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseInfoInFiles": {
+                        "description": "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+                        "type": "string"
+                    },
+                    "fileDependencies": {
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File",
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "fileName",
+                    "copyrightText",
+                    "licenseConcluded"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "snippets": {
+            "description": "Snippets referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "ranges": {
+                        "description": "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "startPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "endPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "startPointer",
+                                "endPointer"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "snippetFromFile": {
+                        "description": "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "licenseInfoInSnippets": {
+                        "description": "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "name",
+                    "snippetFromFile",
+                    "copyrightText",
+                    "licenseConcluded"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "relationships": {
+            "description": "Relationships referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "spdxElementId": {
+                        "type": "string",
+                        "description": "Id to which the SPDX element is related"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "relationshipType": {
+                        "description": "Describes the type of relationship between two SPDX elements.",
+                        "type": "string",
+                        "enum": [
+                            "VARIANT_OF",
+                            "COPY_OF",
+                            "PATCH_FOR",
+                            "TEST_DEPENDENCY_OF",
+                            "CONTAINED_BY",
+                            "DATA_FILE_OF",
+                            "OPTIONAL_COMPONENT_OF",
+                            "ANCESTOR_OF",
+                            "GENERATES",
+                            "CONTAINS",
+                            "OPTIONAL_DEPENDENCY_OF",
+                            "FILE_ADDED",
+                            "DEV_DEPENDENCY_OF",
+                            "DEPENDENCY_OF",
+                            "BUILD_DEPENDENCY_OF",
+                            "DESCRIBES",
+                            "PREREQUISITE_FOR",
+                            "HAS_PREREQUISITE",
+                            "PROVIDED_DEPENDENCY_OF",
+                            "DYNAMIC_LINK",
+                            "DESCRIBED_BY",
+                            "METAFILE_OF",
+                            "DEPENDENCY_MANIFEST_OF",
+                            "PATCH_APPLIED",
+                            "RUNTIME_DEPENDENCY_OF",
+                            "TEST_OF",
+                            "TEST_TOOL_OF",
+                            "DEPENDS_ON",
+                            "FILE_MODIFIED",
+                            "DISTRIBUTION_ARTIFACT",
+                            "DOCUMENTATION_OF",
+                            "GENERATED_FROM",
+                            "STATIC_LINK",
+                            "OTHER",
+                            "BUILD_TOOL_OF",
+                            "TEST_CASE_OF",
+                            "PACKAGE_OF",
+                            "DESCENDANT_OF",
+                            "FILE_DELETED",
+                            "EXPANDED_FROM_ARCHIVE",
+                            "DEV_TOOL_OF",
+                            "EXAMPLE_OF"
+                        ]
+                    },
+                    "relatedSpdxElement": {
+                        "description": "SPDX ID for SpdxElement.  A related SpdxElement.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "spdxElementId",
+                    "relationshipType",
+                    "relatedSpdxElement"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "SPDXID",
+        "name",
+        "spdxVersion",
+        "dataLicense",
+        "creationInfo"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/internal/spdx-v2.3-fix-schema.json
+++ b/schemas/internal/spdx-v2.3-fix-schema.json
@@ -1,0 +1,915 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://spdx.org/rdf/terms",
+    "title": "SPDX 2.2",
+    "type": "object",
+    "required": [
+        "spdxVersion",
+        "dataLicense",
+        "SPDXID",
+        "name",
+        "documentNamespace",
+        "creationInfo"
+    ],
+    "properties": {
+        "spdxVersion": {
+            "description": "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+            "type": "string"
+        },
+        "dataLicense": {
+            "description": "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+            "type": "string"
+        },
+        "SPDXID": {
+            "type": "string",
+            "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+        },
+        "name": {
+            "description": "Identify name of this SpdxElement.",
+            "type": "string"
+        },
+        "documentNamespace": {
+            "type": "string",
+            "description": "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+        },
+        "documentDescribes": {
+            "description": "Packages, files and/or Snippets described by this SPDX document",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "externalDocumentRefs": {
+            "description": "Identify any external SPDX documents referenced within this SPDX document.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "externalDocumentId",
+                    "checksum",
+                    "spdxDocument"
+                ],
+                "properties": {
+                    "externalDocumentId": {
+                        "description": "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                        "type": "string"
+                    },
+                    "checksum": {
+                        "type": "object",
+                        "required": [
+                            "algorithm",
+                            "checksumValue"
+                        ],
+                        "properties": {
+                            "algorithm": {
+                                "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                "type": "string",
+                                "enum": [
+                                    "SHA256",
+                                    "SHA1",
+                                    "SHA384",
+                                    "MD2",
+                                    "MD4",
+                                    "SHA512",
+                                    "MD6",
+                                    "MD5",
+                                    "SHA224"
+                                ]
+                            },
+                            "checksumValue": {
+                                "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                "type": "string"
+                            }
+                        },
+                        "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                    },
+                    "spdxDocument": {
+                        "description": "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+                        "type": "string"
+                    }
+                },
+                "description": "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+            }
+        },
+        "creationInfo": {
+            "type": "object",
+            "required": [
+                "creators",
+                "created"
+            ],
+            "properties": {
+                "licenseListVersion": {
+                    "description": "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+                    "type": "string"
+                },
+                "creators": {
+                    "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                    "type": "array",
+                    "items": {
+                        "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "created": {
+                    "description": "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string",
+                    "description": "an optional field for creator of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields."
+                }
+            },
+            "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "comment": {
+            "type": "string",
+            "description": "an optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document."
+        },
+        "packages": {
+            "description": "Packages referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "SPDXID",
+                    "downloadLocation"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "versionInfo": {
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "type": "string"
+                    },
+                    "packageFileName": {
+                        "description": "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                        "type": "string"
+                    },
+                    "supplier": {
+                        "description": "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "originator": {
+                        "description": "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "downloadLocation": {
+                        "description": "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                        "type": "string"
+                    },
+                    "filesAnalyzed": {
+                        "description": "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                        "type": "boolean"
+                    },
+                    "packageVerificationCode": {
+                        "type": "object",
+                        "required": [
+                            "packageVerificationCodeValue"
+                        ],
+                        "properties": {
+                            "packageVerificationCodeValue": {
+                                "description": "The actual package verification code as a hex encoded value. Use sha1 algorithm",
+                                "type": "string"
+                            },
+                            "packageVerificationCodeExcludedFiles": {
+                                "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "homepage": {
+                        "type": "string"
+                    },
+                    "sourceInfo": {
+                        "description": "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoFromFiles": {
+                        "description": "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseDeclared": {
+                        "description": "License expression for licenseDeclared. See SPDX Annex D for the license expression syntax.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+                        "type": "string"
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "Provides a short description of the package.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Provides a detailed description of the package.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "externalRefs": {
+                        "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "referenceCategory",
+                                "referenceType",
+                                "referenceLocator"
+                            ],
+                            "properties": {
+                                "referenceCategory": {
+                                    "description": "Category for the external reference",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "SECURITY",
+                                        "PACKAGE_MANAGER"
+                                    ]
+                                },
+                                "referenceType": {
+                                    "description": "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                                    "type": "string"
+                                },
+                                "referenceLocator": {
+                                    "description": "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "primaryPackagePurpose": {
+                        "description": "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "INSTALL",
+                            "ARCHIVE",
+                            "FIRMWARE",
+                            "APPLICATION",
+                            "FRAMEWORK",
+                            "LIBRARY",
+                            "CONTAINER",
+                            "SOURCE",
+                            "DEVICE",
+                            "OPERATING_SYSTEM",
+                            "FILE"
+                        ]
+                    },
+                    "releaseDate": {
+                        "description": "This field provides a place for recording the date the package was released.",
+                        "type": "string"
+                    },
+                    "builtDate": {
+                        "description": "This field provides a place for recording the actual date the package was built.",
+                        "type": "string"
+                    },
+                    "validUntilDate": {
+                        "description": "This field provides a place for recording the end of the support period for a package from the supplier.",
+                        "type": "string"
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "hasFiles": {
+                        "description": "Indicates that a particular file belongs to a package.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "files": {
+            "description": "Files referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "fileName",
+                    "SPDXID",
+                    "checksums"
+                ],
+                "properties": {
+                    "fileName": {
+                        "description": "The name of the file relative to the root of the package.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "fileTypes": {
+                        "description": "The type of the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "The type of the file.",
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "DOCUMENTATION",
+                                "IMAGE",
+                                "VIDEO",
+                                "ARCHIVE",
+                                "SPDX",
+                                "APPLICATION",
+                                "SOURCE",
+                                "BINARY",
+                                "TEXT",
+                                "AUDIO"
+                            ]
+                        }
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        },
+                        "minItems": 1
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInFiles": {
+                        "description": "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                            "type": "string"
+                        },
+                        "minItems": 1
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "artifactOfs": {
+                        "description": "Deprecated. Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    },
+                    "comment": {
+                        "description": "This field provides a place for the SPDX file creator to record any general comments about the file.",
+                        "type": "string"
+                    },
+                    "noticeText": {
+                        "description": "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                        "type": "string"
+                    },
+                    "fileContributors": {
+                        "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                            "type": "string"
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "fileDependencies": {
+                        "description": "Deprecated. The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "snippets": {
+            "description": "Snippets referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "SPDXID",
+                    "snippetFromFile",
+                    "ranges"
+                ],
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "snippetFromFile": {
+                        "description": "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                        "type": "string"
+                    },
+                    "ranges": {
+                        "description": "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "endPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                },
+                                "startPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "endPointer",
+                                "startPointer"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInSnippets": {
+                        "description": "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "hasExtractedLicensingInfos": {
+            "description": "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "licenseId",
+                    "extractedText"
+                ],
+                "properties": {
+                    "licenseId": {
+                        "description": "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+                        "type": "string"
+                    },
+                    "extractedText": {
+                        "description": "Verbatim license or licensing notice text that was discovered.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "seeAlsos": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "crossRefs": {
+                        "description": "Cross Reference Detail for a license SeeAlso URL",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "url"
+                            ],
+                            "properties": {
+                                "isWayBackLink": {
+                                    "description": "True if the License SeeAlso URL points to a Wayback archive",
+                                    "type": "boolean"
+                                },
+                                "match": {
+                                    "description": "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                                    "type": "string"
+                                },
+                                "timestamp": {
+                                    "description": "Timestamp",
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "description": "The ordinal order of this element within a list",
+                                    "type": "integer"
+                                },
+                                "url": {
+                                    "description": "URL Reference",
+                                    "type": "string"
+                                },
+                                "isLive": {
+                                    "description": "Indicate a URL is still a live accessible location on the public internet",
+                                    "type": "boolean"
+                                },
+                                "isValid": {
+                                    "description": "True if the URL is a valid well formed URL",
+                                    "type": "boolean"
+                                }
+                            },
+                            "description": "Cross reference details for the a URL reference"
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                },
+                "description": "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+            }
+        },
+        "relationships": {
+            "description": "Relationships referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "spdxElementId",
+                    "relatedSpdxElement",
+                    "relationshipType"
+                ],
+                "properties": {
+                    "spdxElementId": {
+                        "type": "string",
+                        "description": "Id to which the SPDX element is related"
+                    },
+                    "relationshipType": {
+                        "description": "Describes the type of relationship between two SPDX elements.",
+                        "type": "string",
+                        "enum": [
+                            "VARIANT_OF",
+                            "COPY_OF",
+                            "PATCH_FOR",
+                            "TEST_DEPENDENCY_OF",
+                            "CONTAINED_BY",
+                            "DATA_FILE_OF",
+                            "OPTIONAL_COMPONENT_OF",
+                            "ANCESTOR_OF",
+                            "GENERATES",
+                            "CONTAINS",
+                            "OPTIONAL_DEPENDENCY_OF",
+                            "FILE_ADDED",
+                            "DEV_DEPENDENCY_OF",
+                            "DEPENDENCY_OF",
+                            "BUILD_DEPENDENCY_OF",
+                            "DESCRIBES",
+                            "PREREQUISITE_FOR",
+                            "HAS_PREREQUISITE",
+                            "PROVIDED_DEPENDENCY_OF",
+                            "DYNAMIC_LINK",
+                            "DESCRIBED_BY",
+                            "METAFILE_OF",
+                            "DEPENDENCY_MANIFEST_OF",
+                            "PATCH_APPLIED",
+                            "RUNTIME_DEPENDENCY_OF",
+                            "TEST_OF",
+                            "TEST_TOOL_OF",
+                            "DEPENDS_ON",
+                            "FILE_MODIFIED",
+                            "DISTRIBUTION_ARTIFACT",
+                            "DOCUMENTATION_OF",
+                            "GENERATED_FROM",
+                            "STATIC_LINK",
+                            "OTHER",
+                            "BUILD_TOOL_OF",
+                            "TEST_CASE_OF",
+                            "PACKAGE_OF",
+                            "DESCENDANT_OF",
+                            "FILE_DELETED",
+                            "EXPANDED_FROM_ARCHIVE",
+                            "DEV_TOOL_OF",
+                            "EXAMPLE_OF"
+                        ]
+                    },
+                    "relatedSpdxElement": {
+                        "description": "SPDX ID for SpdxElement.  A related SpdxElement.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "annotations": {
+            "description": "Provide additional information about an SpdxElement.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "annotationDate",
+                    "comment",
+                    "annotator",
+                    "annotationType"
+                ],
+                "properties": {
+                    "annotator": {
+                        "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                        "type": "string"
+                    },
+                    "annotationDate": {
+                        "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "annotationType": {
+                        "description": "Type of the annotation.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "REVIEW"
+                        ]
+                    }
+                },
+                "description": "An Annotation is a comment on an SpdxItem by an agent."
+            }
+        },
+        "revieweds": {
+            "description": "Deprecated. Reviewed",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "reviewDate"
+                ],
+                "properties": {
+                    "reviewer": {
+                        "description": "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "reviewDate": {
+                        "description": "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/internal/spdx-v2.3-origin-schema.json
+++ b/schemas/internal/spdx-v2.3-origin-schema.json
@@ -1,0 +1,961 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://spdx.org/rdf/terms/2.3",
+    "title": "SPDX 2.3",
+    "type": "object",
+    "properties": {
+        "SPDXID": {
+            "type": "string",
+            "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+        },
+        "annotations": {
+            "description": "Provide additional information about an SpdxElement.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "annotationDate": {
+                        "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                        "type": "string"
+                    },
+                    "annotationType": {
+                        "description": "Type of the annotation.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "REVIEW"
+                        ]
+                    },
+                    "annotator": {
+                        "description": "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "annotationDate",
+                    "annotationType",
+                    "annotator",
+                    "comment"
+                ],
+                "additionalProperties": false,
+                "description": "An Annotation is a comment on an SpdxItem by an agent."
+            }
+        },
+        "comment": {
+            "type": "string"
+        },
+        "creationInfo": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Identify when the SPDX document was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard.",
+                    "type": "string"
+                },
+                "creators": {
+                    "description": "Identify who (or what, in the case of a tool) created the SPDX document. If the SPDX document was created by an individual, indicate the person's name. If the SPDX document was created on behalf of a company or organization, indicate the entity name. If the SPDX document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "description": "Identify who (or what, in the case of a tool) created the SPDX document. If the SPDX document was created by an individual, indicate the person's name. If the SPDX document was created on behalf of a company or organization, indicate the entity name. If the SPDX document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                        "type": "string"
+                    }
+                },
+                "licenseListVersion": {
+                    "description": "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "created",
+                "creators"
+            ],
+            "additionalProperties": false,
+            "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "dataLicense": {
+            "description": "License expression for dataLicense. See SPDX Annex D for the license expression syntax.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+            "type": "string"
+        },
+        "externalDocumentRefs": {
+            "description": "Identify any external SPDX documents referenced within this SPDX document.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "checksum": {
+                        "type": "object",
+                        "properties": {
+                            "algorithm": {
+                                "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                "type": "string",
+                                "enum": [
+                                    "SHA1",
+                                    "BLAKE3",
+                                    "SHA3-384",
+                                    "SHA256",
+                                    "SHA384",
+                                    "BLAKE2b-512",
+                                    "BLAKE2b-256",
+                                    "SHA3-512",
+                                    "MD2",
+                                    "ADLER32",
+                                    "MD4",
+                                    "SHA3-256",
+                                    "BLAKE2b-384",
+                                    "SHA512",
+                                    "MD6",
+                                    "MD5",
+                                    "SHA224"
+                                ]
+                            },
+                            "checksumValue": {
+                                "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "algorithm",
+                            "checksumValue"
+                        ],
+                        "additionalProperties": false,
+                        "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                    },
+                    "externalDocumentId": {
+                        "description": "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                        "type": "string"
+                    },
+                    "spdxDocument": {
+                        "description": "SPDX ID for SpdxDocument.  A property containing an SPDX document.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "checksum",
+                    "externalDocumentId",
+                    "spdxDocument"
+                ],
+                "additionalProperties": false,
+                "description": "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+            }
+        },
+        "hasExtractedLicensingInfos": {
+            "description": "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "comment": {
+                        "type": "string"
+                    },
+                    "crossRefs": {
+                        "description": "Cross Reference Detail for a license SeeAlso URL",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "isLive": {
+                                    "description": "Indicate a URL is still a live accessible location on the public internet",
+                                    "type": "boolean"
+                                },
+                                "isValid": {
+                                    "description": "True if the URL is a valid well formed URL",
+                                    "type": "boolean"
+                                },
+                                "isWayBackLink": {
+                                    "description": "True if the License SeeAlso URL points to a Wayback archive",
+                                    "type": "boolean"
+                                },
+                                "match": {
+                                    "description": "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "description": "The ordinal order of this element within a list",
+                                    "type": "integer"
+                                },
+                                "timestamp": {
+                                    "description": "Timestamp",
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "description": "URL Reference",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "url"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Cross reference details for the a URL reference"
+                        }
+                    },
+                    "extractedText": {
+                        "description": "Provide a copy of the actual text of the license reference extracted from the package, file or snippet that is associated with the License Identifier to aid in future analysis.",
+                        "type": "string"
+                    },
+                    "licenseId": {
+                        "description": "A human readable short form license identifier for a license. The license ID is either on the standard license list or the form \"LicenseRef-[idString]\" where [idString] is a unique string containing letters, numbers, \".\" or \"-\".  When used within a license expression, the license ID can optionally include a reference to an external document in the form \"DocumentRef-[docrefIdString]:LicenseRef-[idString]\" where docRefIdString is an ID for an external document reference.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "seeAlsos": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "extractedText",
+                    "licenseId"
+                ],
+                "additionalProperties": false,
+                "description": "An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+            }
+        },
+        "name": {
+            "description": "Identify name of this SpdxElement.",
+            "type": "string"
+        },
+        "revieweds": {
+            "description": "Reviewed",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "comment": {
+                        "type": "string"
+                    },
+                    "reviewDate": {
+                        "description": "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                        "type": "string"
+                    },
+                    "reviewer": {
+                        "description": "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.  The reviewer property is deprecated in favor of Annotation with an annotationType review.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "reviewDate"
+                ],
+                "additionalProperties": false,
+                "description": "This class has been deprecated in favor of an Annotation with an Annotation type of review."
+            }
+        },
+        "spdxVersion": {
+            "description": "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+            "type": "string"
+        },
+        "documentNamespace": {
+            "type": "string",
+            "description": "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+        },
+        "documentDescribes": {
+            "description": "Packages, files and/or Snippets described by this SPDX document",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "SPDX ID for each Package, File, or Snippet."
+            }
+        },
+        "packages": {
+            "description": "Packages referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "annotationType",
+                                "annotator",
+                                "comment"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "builtDate": {
+                        "description": "This field provides a place for recording the actual date the package was built.",
+                        "type": "string"
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA1",
+                                        "BLAKE3",
+                                        "SHA3-384",
+                                        "SHA256",
+                                        "SHA384",
+                                        "BLAKE2b-512",
+                                        "BLAKE2b-256",
+                                        "SHA3-512",
+                                        "MD2",
+                                        "ADLER32",
+                                        "MD4",
+                                        "SHA3-256",
+                                        "BLAKE2b-384",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "additionalProperties": false,
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Provides a detailed description of the package.",
+                        "type": "string"
+                    },
+                    "downloadLocation": {
+                        "description": "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                        "type": "string"
+                    },
+                    "externalRefs": {
+                        "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "referenceCategory": {
+                                    "description": "Category for the external reference",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "PERSISTENT-ID",
+                                        "SECURITY",
+                                        "PACKAGE-MANAGER"
+                                    ]
+                                },
+                                "referenceLocator": {
+                                    "description": "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                                    "type": "string"
+                                },
+                                "referenceType": {
+                                    "description": "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "referenceCategory",
+                                "referenceLocator",
+                                "referenceType"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                        }
+                    },
+                    "filesAnalyzed": {
+                        "description": "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                        "type": "boolean"
+                    },
+                    "hasFiles": {
+                        "description": "Indicates that a particular file belongs to a package.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                            "type": "string"
+                        }
+                    },
+                    "homepage": {
+                        "type": "string"
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseDeclared": {
+                        "description": "License expression for licenseDeclared. See SPDX Annex D for the license expression syntax.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+                        "type": "string"
+                    },
+                    "licenseInfoFromFiles": {
+                        "description": "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoFromFiles. See SPDX Annex D for the license expression syntax.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "originator": {
+                        "description": "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "packageFileName": {
+                        "description": "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                        "type": "string"
+                    },
+                    "packageVerificationCode": {
+                        "type": "object",
+                        "properties": {
+                            "packageVerificationCodeExcludedFiles": {
+                                "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                    "type": "string"
+                                }
+                            },
+                            "packageVerificationCodeValue": {
+                                "description": "The actual package verification code as a hex encoded value.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "packageVerificationCodeValue"
+                        ],
+                        "additionalProperties": false,
+                        "description": "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+                    },
+                    "primaryPackagePurpose": {
+                        "description": "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "INSTALL",
+                            "ARCHIVE",
+                            "FIRMWARE",
+                            "APPLICATION",
+                            "FRAMEWORK",
+                            "LIBRARY",
+                            "CONTAINER",
+                            "SOURCE",
+                            "DEVICE",
+                            "OPERATING_SYSTEM",
+                            "FILE"
+                        ]
+                    },
+                    "releaseDate": {
+                        "description": "This field provides a place for recording the date the package was released.",
+                        "type": "string"
+                    },
+                    "sourceInfo": {
+                        "description": "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "Provides a short description of the package.",
+                        "type": "string"
+                    },
+                    "supplier": {
+                        "description": "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "validUntilDate": {
+                        "description": "This field provides a place for recording the end of the support period for a package from the supplier.",
+                        "type": "string"
+                    },
+                    "versionInfo": {
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "downloadLocation",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "files": {
+            "description": "Files referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "annotationType",
+                                "annotator",
+                                "comment"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "artifactOfs": {
+                        "description": "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA1",
+                                        "BLAKE3",
+                                        "SHA3-384",
+                                        "SHA256",
+                                        "SHA384",
+                                        "BLAKE2b-512",
+                                        "BLAKE2b-256",
+                                        "SHA3-512",
+                                        "MD2",
+                                        "ADLER32",
+                                        "MD4",
+                                        "SHA3-256",
+                                        "BLAKE2b-384",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "additionalProperties": false,
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "fileContributors": {
+                        "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                            "type": "string"
+                        }
+                    },
+                    "fileDependencies": {
+                        "description": "This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",
+                            "type": "string"
+                        }
+                    },
+                    "fileName": {
+                        "description": "The name of the file relative to the root of the package.",
+                        "type": "string"
+                    },
+                    "fileTypes": {
+                        "description": "The type of the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "The type of the file.",
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "DOCUMENTATION",
+                                "IMAGE",
+                                "VIDEO",
+                                "ARCHIVE",
+                                "SPDX",
+                                "APPLICATION",
+                                "SOURCE",
+                                "BINARY",
+                                "TEXT",
+                                "AUDIO"
+                            ]
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInFiles": {
+                        "description": "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.\n\nIf the licenseInfoInFile field is not present for a file, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInFile. See SPDX Annex D for the license expression syntax.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.\n\nIf the licenseInfoInFile field is not present for a file, it implies an equivalent meaning to NOASSERTION.",
+                            "type": "string"
+                        }
+                    },
+                    "noticeText": {
+                        "description": "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "checksums",
+                    "fileName"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "snippets": {
+            "description": "Snippets referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "annotationDate",
+                                "annotationType",
+                                "annotator",
+                                "comment"
+                            ],
+                            "additionalProperties": false,
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInSnippets": {
+                        "description": "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.\n\nIf the licenseInfoInSnippet field is not present for a snippet, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInSnippet. See SPDX Annex D for the license expression syntax.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.\n\nIf the licenseInfoInSnippet field is not present for a snippet, it implies an equivalent meaning to NOASSERTION.",
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "ranges": {
+                        "description": "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "endPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "startPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "endPointer",
+                                "startPointer"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "snippetFromFile": {
+                        "description": "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "SPDXID",
+                    "name",
+                    "ranges",
+                    "snippetFromFile"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "relationships": {
+            "description": "Relationships referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "spdxElementId": {
+                        "type": "string",
+                        "description": "Id to which the SPDX element is related"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "relatedSpdxElement": {
+                        "description": "SPDX ID for SpdxElement.  A related SpdxElement.",
+                        "type": "string"
+                    },
+                    "relationshipType": {
+                        "description": "Describes the type of relationship between two SPDX elements.",
+                        "type": "string",
+                        "enum": [
+                            "VARIANT_OF",
+                            "COPY_OF",
+                            "PATCH_FOR",
+                            "TEST_DEPENDENCY_OF",
+                            "CONTAINED_BY",
+                            "DATA_FILE_OF",
+                            "OPTIONAL_COMPONENT_OF",
+                            "ANCESTOR_OF",
+                            "GENERATES",
+                            "CONTAINS",
+                            "OPTIONAL_DEPENDENCY_OF",
+                            "FILE_ADDED",
+                            "REQUIREMENT_DESCRIPTION_FOR",
+                            "DEV_DEPENDENCY_OF",
+                            "DEPENDENCY_OF",
+                            "BUILD_DEPENDENCY_OF",
+                            "DESCRIBES",
+                            "PREREQUISITE_FOR",
+                            "HAS_PREREQUISITE",
+                            "PROVIDED_DEPENDENCY_OF",
+                            "DYNAMIC_LINK",
+                            "DESCRIBED_BY",
+                            "METAFILE_OF",
+                            "DEPENDENCY_MANIFEST_OF",
+                            "PATCH_APPLIED",
+                            "RUNTIME_DEPENDENCY_OF",
+                            "TEST_OF",
+                            "TEST_TOOL_OF",
+                            "DEPENDS_ON",
+                            "SPECIFICATION_FOR",
+                            "FILE_MODIFIED",
+                            "DISTRIBUTION_ARTIFACT",
+                            "AMENDS",
+                            "DOCUMENTATION_OF",
+                            "GENERATED_FROM",
+                            "STATIC_LINK",
+                            "OTHER",
+                            "BUILD_TOOL_OF",
+                            "TEST_CASE_OF",
+                            "PACKAGE_OF",
+                            "DESCENDANT_OF",
+                            "FILE_DELETED",
+                            "EXPANDED_FROM_ARCHIVE",
+                            "DEV_TOOL_OF",
+                            "EXAMPLE_OF"
+                        ]
+                    }
+                },
+                "required": [
+                    "spdxElementId",
+                    "relatedSpdxElement",
+                    "relationshipType"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "SPDXID",
+        "creationInfo",
+        "dataLicense",
+        "name",
+        "spdxVersion"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/openchain-telco-guide-v1.0-schema.json
+++ b/schemas/openchain-telco-guide-v1.0-schema.json
@@ -1,0 +1,924 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/OpenChain-Project/Telco-WG",
+    "title": "Open Chain Telco Guide 1.0",
+    "type": "object",
+    "required": [
+        "spdxVersion",
+        "dataLicense",
+        "SPDXID",
+        "name",
+        "documentNamespace",
+        "creationInfo"
+    ],
+    "properties": {
+        "spdxVersion": {
+            "description": "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+            "type": "string"
+        },
+        "dataLicense": {
+            "description": "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+            "type": "string"
+        },
+        "SPDXID": {
+            "type": "string",
+            "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+        },
+        "name": {
+            "description": "Identify name of this SpdxElement.",
+            "type": "string"
+        },
+        "documentNamespace": {
+            "type": "string",
+            "description": "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+        },
+        "documentDescribes": {
+            "description": "Packages, files and/or Snippets described by this SPDX document",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "externalDocumentRefs": {
+            "description": "Identify any external SPDX documents referenced within this SPDX document.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "externalDocumentId",
+                    "checksum",
+                    "spdxDocument"
+                ],
+                "properties": {
+                    "externalDocumentId": {
+                        "description": "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                        "type": "string"
+                    },
+                    "checksum": {
+                        "type": "object",
+                        "required": [
+                            "algorithm",
+                            "checksumValue"
+                        ],
+                        "properties": {
+                            "algorithm": {
+                                "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                "type": "string",
+                                "enum": [
+                                    "SHA256",
+                                    "SHA1",
+                                    "SHA384",
+                                    "MD2",
+                                    "MD4",
+                                    "SHA512",
+                                    "MD6",
+                                    "MD5",
+                                    "SHA224"
+                                ]
+                            },
+                            "checksumValue": {
+                                "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                "type": "string"
+                            }
+                        },
+                        "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                    },
+                    "spdxDocument": {
+                        "description": "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+                        "type": "string"
+                    }
+                },
+                "description": "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+            }
+        },
+        "creationInfo": {
+            "type": "object",
+            "required": [
+                "creators",
+                "created"
+            ],
+            "properties": {
+                "licenseListVersion": {
+                    "description": "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+                    "type": "string"
+                },
+                "creators": {
+                    "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                    "type": "array",
+                    "items": {
+                        "description": "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                        "type": "string"
+                    },
+                    "minItems": 2
+                },
+                "created": {
+                    "description": "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string",
+                    "description": "an optional field for creator of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields."
+                }
+            },
+            "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "comment": {
+            "type": "string",
+            "description": "an optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document."
+        },
+        "packages": {
+            "description": "Packages referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "SPDXID",
+                    "downloadLocation",
+                    "licenseConcluded",
+                    "licenseDeclared",
+                    "copyrightText",
+                    "supplier",
+                    "version"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "versionInfo": {
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "type": "string"
+                    },
+                    "packageFileName": {
+                        "description": "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                        "type": "string"
+                    },
+                    "supplier": {
+                        "description": "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "originator": {
+                        "description": "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "downloadLocation": {
+                        "description": "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                        "type": "string"
+                    },
+                    "filesAnalyzed": {
+                        "description": "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                        "type": "boolean"
+                    },
+                    "packageVerificationCode": {
+                        "type": "object",
+                        "required": [
+                            "packageVerificationCodeValue"
+                        ],
+                        "properties": {
+                            "packageVerificationCodeValue": {
+                                "description": "The actual package verification code as a hex encoded value. Use sha1 algorithm",
+                                "type": "string"
+                            },
+                            "packageVerificationCodeExcludedFiles": {
+                                "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        }
+                    },
+                    "homepage": {
+                        "type": "string"
+                    },
+                    "sourceInfo": {
+                        "description": "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                        "type": "string"
+                    },
+                    "licenseConcluded": {
+                        "description": "Telco Guide required mandatory. License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoFromFiles": {
+                        "description": "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseDeclared": {
+                        "description": "Telco Guide required mandatory. License expression for licenseDeclared. See SPDX Annex D for the license expression syntax.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+                        "type": "string"
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "Telco Guide required mandatory. The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "Provides a short description of the package.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Provides a detailed description of the package.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "externalRefs": {
+                        "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package. A package SHOULD be identified by a Package URL (PURL). The PURL SHOULD be put in ExternalRef field",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "referenceCategory",
+                                "referenceType",
+                                "referenceLocator"
+                            ],
+                            "properties": {
+                                "referenceCategory": {
+                                    "description": "Category for the external reference",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "SECURITY",
+                                        "PACKAGE_MANAGER"
+                                    ]
+                                },
+                                "referenceType": {
+                                    "description": "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                                    "type": "string"
+                                },
+                                "referenceLocator": {
+                                    "description": "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                }
+                            },
+                            "description": "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "primaryPackagePurpose": {
+                        "description": "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "INSTALL",
+                            "ARCHIVE",
+                            "FIRMWARE",
+                            "APPLICATION",
+                            "FRAMEWORK",
+                            "LIBRARY",
+                            "CONTAINER",
+                            "SOURCE",
+                            "DEVICE",
+                            "OPERATING_SYSTEM",
+                            "FILE"
+                        ]
+                    },
+                    "releaseDate": {
+                        "description": "This field provides a place for recording the date the package was released.",
+                        "type": "string"
+                    },
+                    "builtDate": {
+                        "description": "This field provides a place for recording the actual date the package was built.",
+                        "type": "string"
+                    },
+                    "validUntilDate": {
+                        "description": "This field provides a place for recording the end of the support period for a package from the supplier.",
+                        "type": "string"
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    },
+                    "hasFiles": {
+                        "description": "Indicates that a particular file belongs to a package.",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                            "type": "string"
+                        }
+                    },
+                    "version": {
+                        "description": "Telco Guide required mandatory.",
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "files": {
+            "description": "Files referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "fileName",
+                    "SPDXID",
+                    "checksums"
+                ],
+                "properties": {
+                    "fileName": {
+                        "description": "The name of the file relative to the root of the package.",
+                        "type": "string"
+                    },
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "fileTypes": {
+                        "description": "The type of the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "The type of the file.",
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "DOCUMENTATION",
+                                "IMAGE",
+                                "VIDEO",
+                                "ARCHIVE",
+                                "SPDX",
+                                "APPLICATION",
+                                "SOURCE",
+                                "BINARY",
+                                "TEXT",
+                                "AUDIO"
+                            ]
+                        }
+                    },
+                    "checksums": {
+                        "description": "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "algorithm",
+                                "checksumValue"
+                            ],
+                            "properties": {
+                                "algorithm": {
+                                    "description": "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                                    "type": "string",
+                                    "enum": [
+                                        "SHA256",
+                                        "SHA1",
+                                        "SHA384",
+                                        "MD2",
+                                        "MD4",
+                                        "SHA512",
+                                        "MD6",
+                                        "MD5",
+                                        "SHA224"
+                                    ]
+                                },
+                                "checksumValue": {
+                                    "description": "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                                    "type": "string"
+                                }
+                            },
+                            "description": "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                        },
+                        "minItems": 1
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInFiles": {
+                        "description": "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                            "type": "string"
+                        },
+                        "minItems": 1
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "artifactOfs": {
+                        "description": "Deprecated. Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    },
+                    "comment": {
+                        "description": "This field provides a place for the SPDX file creator to record any general comments about the file.",
+                        "type": "string"
+                    },
+                    "noticeText": {
+                        "description": "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                        "type": "string"
+                    },
+                    "fileContributors": {
+                        "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                            "type": "string"
+                        }
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "fileDependencies": {
+                        "description": "Deprecated. The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build",
+                        "type": "array",
+                        "items": {
+                            "description": "SPDX ID for File",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "snippets": {
+            "description": "Snippets referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "SPDXID",
+                    "snippetFromFile",
+                    "ranges"
+                ],
+                "properties": {
+                    "SPDXID": {
+                        "type": "string",
+                        "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+                    },
+                    "snippetFromFile": {
+                        "description": "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                        "type": "string"
+                    },
+                    "ranges": {
+                        "description": "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "endPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                },
+                                "startPointer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "reference": {
+                                            "description": "SPDX ID for File",
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Byte offset in the file"
+                                        },
+                                        "lineNumber": {
+                                            "type": "integer",
+                                            "description": "line number offset in the file"
+                                        }
+                                    },
+                                    "required": [
+                                        "reference"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "endPointer",
+                                "startPointer"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "licenseConcluded": {
+                        "description": "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+                        "type": "string"
+                    },
+                    "licenseInfoInSnippets": {
+                        "description": "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                        "type": "array",
+                        "items": {
+                            "description": "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                            "type": "string"
+                        }
+                    },
+                    "licenseComments": {
+                        "description": "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                        "type": "string"
+                    },
+                    "copyrightText": {
+                        "description": "The text of copyright declarations recited in the Package or File.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "attributionTexts": {
+                        "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                        "type": "array",
+                        "items": {
+                            "description": "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Provide additional information about an SpdxElement.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "annotationDate",
+                                "comment",
+                                "annotator",
+                                "annotationType"
+                            ],
+                            "properties": {
+                                "annotationDate": {
+                                    "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                                    "type": "string"
+                                },
+                                "comment": {
+                                    "type": "string"
+                                },
+                                "annotator": {
+                                    "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                                    "type": "string"
+                                },
+                                "annotationType": {
+                                    "description": "Type of the annotation.",
+                                    "type": "string",
+                                    "enum": [
+                                        "OTHER",
+                                        "REVIEW"
+                                    ]
+                                }
+                            },
+                            "description": "An Annotation is a comment on an SpdxItem by an agent."
+                        }
+                    }
+                }
+            }
+        },
+        "hasExtractedLicensingInfos": {
+            "description": "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "licenseId",
+                    "extractedText"
+                ],
+                "properties": {
+                    "licenseId": {
+                        "description": "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+                        "type": "string"
+                    },
+                    "extractedText": {
+                        "description": "Verbatim license or licensing notice text that was discovered.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Identify name of this SpdxElement.",
+                        "type": "string"
+                    },
+                    "seeAlsos": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "crossRefs": {
+                        "description": "Cross Reference Detail for a license SeeAlso URL",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "url"
+                            ],
+                            "properties": {
+                                "isWayBackLink": {
+                                    "description": "True if the License SeeAlso URL points to a Wayback archive",
+                                    "type": "boolean"
+                                },
+                                "match": {
+                                    "description": "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                                    "type": "string"
+                                },
+                                "timestamp": {
+                                    "description": "Timestamp",
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "description": "The ordinal order of this element within a list",
+                                    "type": "integer"
+                                },
+                                "url": {
+                                    "description": "URL Reference",
+                                    "type": "string"
+                                },
+                                "isLive": {
+                                    "description": "Indicate a URL is still a live accessible location on the public internet",
+                                    "type": "boolean"
+                                },
+                                "isValid": {
+                                    "description": "True if the URL is a valid well formed URL",
+                                    "type": "boolean"
+                                }
+                            },
+                            "description": "Cross reference details for the a URL reference"
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                },
+                "description": "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+            }
+        },
+        "relationships": {
+            "description": "Relationships referenced in the SPDX document",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "spdxElementId",
+                    "relatedSpdxElement",
+                    "relationshipType"
+                ],
+                "properties": {
+                    "spdxElementId": {
+                        "type": "string",
+                        "description": "Id to which the SPDX element is related"
+                    },
+                    "relationshipType": {
+                        "description": "Describes the type of relationship between two SPDX elements.",
+                        "type": "string",
+                        "enum": [
+                            "VARIANT_OF",
+                            "COPY_OF",
+                            "PATCH_FOR",
+                            "TEST_DEPENDENCY_OF",
+                            "CONTAINED_BY",
+                            "DATA_FILE_OF",
+                            "OPTIONAL_COMPONENT_OF",
+                            "ANCESTOR_OF",
+                            "GENERATES",
+                            "CONTAINS",
+                            "OPTIONAL_DEPENDENCY_OF",
+                            "FILE_ADDED",
+                            "DEV_DEPENDENCY_OF",
+                            "DEPENDENCY_OF",
+                            "BUILD_DEPENDENCY_OF",
+                            "DESCRIBES",
+                            "PREREQUISITE_FOR",
+                            "HAS_PREREQUISITE",
+                            "PROVIDED_DEPENDENCY_OF",
+                            "DYNAMIC_LINK",
+                            "DESCRIBED_BY",
+                            "METAFILE_OF",
+                            "DEPENDENCY_MANIFEST_OF",
+                            "PATCH_APPLIED",
+                            "RUNTIME_DEPENDENCY_OF",
+                            "TEST_OF",
+                            "TEST_TOOL_OF",
+                            "DEPENDS_ON",
+                            "FILE_MODIFIED",
+                            "DISTRIBUTION_ARTIFACT",
+                            "DOCUMENTATION_OF",
+                            "GENERATED_FROM",
+                            "STATIC_LINK",
+                            "OTHER",
+                            "BUILD_TOOL_OF",
+                            "TEST_CASE_OF",
+                            "PACKAGE_OF",
+                            "DESCENDANT_OF",
+                            "FILE_DELETED",
+                            "EXPANDED_FROM_ARCHIVE",
+                            "DEV_TOOL_OF",
+                            "EXAMPLE_OF"
+                        ]
+                    },
+                    "relatedSpdxElement": {
+                        "description": "SPDX ID for SpdxElement.  A related SpdxElement.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "annotations": {
+            "description": "Provide additional information about an SpdxElement.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "annotationDate",
+                    "comment",
+                    "annotator",
+                    "annotationType"
+                ],
+                "properties": {
+                    "annotator": {
+                        "description": "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                        "type": "string"
+                    },
+                    "annotationDate": {
+                        "description": "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "annotationType": {
+                        "description": "Type of the annotation.",
+                        "type": "string",
+                        "enum": [
+                            "OTHER",
+                            "REVIEW"
+                        ]
+                    }
+                },
+                "description": "An Annotation is a comment on an SpdxItem by an agent."
+            }
+        },
+        "revieweds": {
+            "description": "Deprecated. Reviewed",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "reviewDate"
+                ],
+                "properties": {
+                    "reviewer": {
+                        "description": "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+                        "type": "string"
+                    },
+                    "reviewDate": {
+                        "description": "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/openchain-telco-sbom-guide-1.0-schema.json
+++ b/schemas/openchain-telco-sbom-guide-1.0-schema.json
@@ -95,7 +95,8 @@
             "type": "object",
             "required": [
                 "creators",
-                "created"
+                "created",
+                "comment"
             ],
             "properties": {
                 "licenseListVersion": {
@@ -117,7 +118,7 @@
                 },
                 "comment": {
                     "type": "string",
-                    "description": "an optional field for creator of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields."
+                    "description": "Mandatory. MUST provide SBOM Type as defined by CISA in the field."
                 }
             },
             "description": "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
@@ -134,12 +135,12 @@
                 "required": [
                     "name",
                     "SPDXID",
+                    "versionInfo",
                     "downloadLocation",
                     "licenseConcluded",
                     "licenseDeclared",
                     "copyrightText",
-                    "supplier",
-                    "version"
+                    "supplier"
                 ],
                 "properties": {
                     "name": {
@@ -151,7 +152,7 @@
                         "description": "Uniquely identify any element in an SPDX document which may be referenced by other elements."
                     },
                     "versionInfo": {
-                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                        "description": "Provides an indication of the version of the package that is described by this SpdxDocument. Telco Guide required mandatory.",
                         "type": "string"
                     },
                     "packageFileName": {
@@ -385,10 +386,6 @@
                             "description": "SPDX ID for File.  Indicates that a particular file belongs to a package.",
                             "type": "string"
                         }
-                    },
-                    "version": {
-                        "description": "Telco Guide required mandatory.",
-                        "type": "string"
                     }
                 }
             }


### PR DESCRIPTION
It took a long time to calibrate json schemas for Telco guide 1.0. The underlying logic can be see in [link](https://github.com/ammend/Telco-WG/tree/main/schemas). This pull request add a json schema for Telco guide 1.0 and give comparison between spdx 2.2 and 2.3 and developed a python script to do this. Thanks for your review! 