### PR TITLE
PackageLicenseConcluded and PackageLicenseDeclared are not mandatory …

### DIFF
--- a/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
+++ b/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
@@ -87,8 +87,8 @@ Package information
 * PackageDownloadLocation: mandatory in SPDX
 * FilesAnalyzed
 * PackageChecksum: recommended by “NTIA SBOM Minimum elements”
-* PackageLicenseConcluded: mandatory in SPDX
-* PackageLicenseDeclared: mandatory in SPDX
+* PackageLicenseConcluded: mandatory in SPDX 2.2
+* PackageLicenseDeclared: mandatory in SPDX 2.2
 * PackageCopyrightText: mandatory in SPDX
 * ExternalRef: to be able to put the Package URL
 


### PR DESCRIPTION
…in SPDX 2.3

Fixes https://github.com/OpenChain-Project/Telco-WG/issues/130