### PR TITLE
Inconsitency between PURL and ExternalRef

### DIFF
--- a/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
+++ b/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
@@ -90,11 +90,10 @@ Package information
 * PackageLicenseConcluded: mandatory in SPDX
 * PackageLicenseDeclared: mandatory in SPDX
 * PackageCopyrightText: mandatory in SPDX
-* ExternalRef: to be able to put the Package URL
 
 A package SHOULD be identified by a Package URL (PURL).
 
-The PURL SHOULD be put in ExternalRef field, e.g.
+If the PURL is present, it SHOULD be put in ExternalRef field, e.g.
 ```
 ExternalRef: PACKAGE-MANAGER purl pkg:pypi/django@1.11.1
 ```


### PR DESCRIPTION
In the Guide version 1.0, we say:
- that the ExternalRef field is REQUIRED "to be able to put the Package URL"
- that "A package SHOULD be identified by a Package URL (PURL). The PURL SHOULD be put in ExternalRef field"

To be more consistent, I suggest to say that the ExternalRef field SHOULD be present to be able to put the Package URL.

Fixes https://github.com/OpenChain-Project/Telco-WG/issues/120