### PR TITLE
As discussed in the December meeting, the package hash is RECOMMENDED.

### DIFF
--- a/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
+++ b/OpenChain-Telco-SBOM-Guide_1.1_draft_EN.md
@@ -89,7 +89,7 @@ Package information
 * PackageLicenseDeclared: mandatory in SPDX 2.2
 * PackageCopyrightText: mandatory in SPDX
 
-One of the two attributes PackageChecksum or PackageVerificationCode is MANDATORY:
+One of the two attributes PackageChecksum or PackageVerificationCode is RECOMMENDED:
 recommended by “NTIA SBOM Minimum elements”
 
 A package SHOULD be identified by a Package URL (PURL).
@@ -106,11 +106,11 @@ Relationships between SPDX elements
 NTIA minimum elements
 
 #### 3.2.2 Rationale
-Recognizing the Telco industry need for harmonization and special requirements, possibly beyond the NTIA minimum elements, the “OpenChain Telco SBOM Guide” is proposed to ensure predictability to the industry as to the elements of an SBOM that is expected.
+Recognizing the Telco industry need for harmonization and special requirements, the “OpenChain Telco SBOM Guide” is proposed to ensure predictability to the industry as to the elements of an SBOM that is expected.
 
 “Component Hash” is recommended, but not required by the “NTIA SBOM Minimum elements”.
+
 In SPDX, it maps to PackageChecksum or PackageVerificationCode.
-We make it mandatory as it is important to uniquely identify a package.
 Most SCA tools have the capability to produce hashes.
 
 The CISA document "Framing Software Component Transparency: Establishing a Common Software Bill of Materials (SBOM), Third Edition"


### PR DESCRIPTION
Previously, it was MANDATORY.
It might be difficult in some cases to provide the hash. The PURL should be enough to identify the packege.