### PR TITLE
Fix test "test_nok_purls"

### DIFF
--- a/tools/openchain_telco_sbom_validator/unittests/test_validator_package.py
+++ b/tools/openchain_telco_sbom_validator/unittests/test_validator_package.py
@@ -13,7 +13,7 @@ def test_nok_supplier_missing():
 
 def test_nok_purls():
     v = validator.Validator()
-    result, problems = v.validate(filePath = "sboms/unittest-sbom-12.spdx", strict_purl_check=True, strict_url_check=True)
+    result, problems = v.validate(filePath = "sboms/unittest-sbom-12.spdx", strict_url_check=True)
     print(f"{problems[0].ErrorType}, {problems[0].Reason}, {problems[0].SPDX_ID}, {problems[0].PackageName}")
     assert result == False
     assert len(problems) == 1


### PR DESCRIPTION
Removing strict_purl_check=True
Previously, it had no effect as --strict was not present.
This test tests only wrong URL.